### PR TITLE
fix: handle Netease quality mismatch without interrupting flow

### DIFF
--- a/modules/wy/__init__.py
+++ b/modules/wy/__init__.py
@@ -78,15 +78,19 @@ async def url(songId, quality):
         expected_level = tools["qualityMap"][quality]
     
         # 检查客户端请求的 quality 与服务器返回的 level 是否匹配
-        if data_level != expected_level:
-            raise FailedException(
-                f"reject unmatched quality: expected={expected_level}, got={data_level}"
-            )
+        try:
+            if data_level != expected_level:
+                raise FailedException(
+                    f"reject unmatched quality: expected={expected_level}, got={data_level}"
+                )
+        except FailedException:
+            print(f"Warning: Quality has changed from {expected_level} to {data_level}")
         
         return {
             'url': data["url"].split("?")[0],
             'quality': tools['qualityMapReverse'][data['level']]
         }
+
     elif (PROTO == "ncmapi") and (API_URL):
         requestUrl = f"{API_URL}/song/url/v1"
         requestBody = {
@@ -108,12 +112,15 @@ async def url(songId, quality):
         expected_level = tools["qualityMap"][quality]
     
         # 检查客户端请求的 quality 与服务器返回的 level 是否匹配
-        if data_level != expected_level:
-            raise FailedException(
-                f"reject unmatched quality: expected={expected_level}, got={data_level}"
-            )
-    
+        try:
+            if data_level != expected_level:
+                raise FailedException(
+                    f"reject unmatched quality: expected={expected_level}, got={data_level}"
+                )
+        except FailedException:
+            print(f"Warning: Quality has changed from {expected_level} to {data_level}")
+        
         return {
             'url': data["url"].split("?")[0],
-            'quality': quality
+            'quality': tools['qualityMapReverse'][data['level']]
         }


### PR DESCRIPTION
Fix #94 
现在会抛出异常但正常获取相应的音质
![725fe25d0b7f47ca7b6a774e26ad8679](https://github.com/user-attachments/assets/ed587a61-4576-4992-9f5b-3f2d55c67d4f)
